### PR TITLE
feat(terminal): implement InlineImageProtocol for Sixel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,10 +261,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -580,6 +612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +711,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -873,6 +917,16 @@ dependencies = [
  "zerofrom",
  "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1287,6 +1341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1314,12 +1369,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1540,6 +1628,7 @@ dependencies = [
  "base64",
  "gethostname",
  "glob",
+ "icy_sixel",
  "image",
  "insta",
  "mime",
@@ -1578,6 +1667,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float",
+ "palette",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1721,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1655,6 +1770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1850,6 +1974,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2139,15 @@ dependencies = [
  "unicode-ccc",
  "unicode-properties",
  "unicode-script",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -2272,6 +2425,12 @@ dependencies = [
  "sys-locale",
  "web-sys",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "temp-env"
@@ -2775,6 +2934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +3117,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xmlwriter"

--- a/README.md
+++ b/README.md
@@ -30,22 +30,26 @@ Then it
 - shows [links][osc8], and also images inline in supported terminals (see above, where "Rust" is a clickable link!),
 - adds jump marks for headings in [iTerm2] (jump forwards and backwards with <key>⇧⌘↓</key> and <key>⇧⌘↑</key>).
 
-| Terminal           | Basic syntax | Syntax highlighting | Images | Math | Jump marks |
-| :----------------- | :----------: | :-----------------: | :----: | :--: | :--------: |
-| Basic ANSI¹        |      ✓       |          ✓          |        |  ✓³  |            |
-| Windows 10 console |      ✓       |          ✓          |        |  ✓³  |            |
-| [iTerm2]           |      ✓       |          ✓          |   ✓²   |  ✓³  |     ✓      |
-| [kitty]            |      ✓       |          ✓          |   ✓²   |  ✓³  |            |
-| [WezTerm]          |      ✓       |          ✓          |   ✓²   |  ✓³  |            |
-| [VSCode]           |      ✓       |          ✓          |        |  ✓³  |            |
-| [Ghostty]          |      ✓       |          ✓          |   ✓²   |  ✓³  |            |
+| Terminal           | Basic syntax | Syntax highlighting | Images | Math  | Jump marks |
+| :----------------- | :----------: | :-----------------: | :----: | :---: | :--------: |
+| Basic ANSI¹        |      ✓       |          ✓          |        |  ✓³   |            |
+| Windows 10 console |      ✓       |          ✓          |        |  ✓³   |            |
+| [iTerm2]           |      ✓       |          ✓          |   ✓²   |  ✓³   |     ✓      |
+| [kitty]            |      ✓       |          ✓          |   ✓²   |  ✓³   |            |
+| [WezTerm]          |      ✓       |          ✓          |   ✓²   |  ✓³   |            |
+| [VSCode]           |      ✓       |          ✓          |        |  ✓³   |            |
+| [Ghostty]          |      ✓       |          ✓          |   ✓²   |  ✓³   |            |
+| [foot]⁴            |      ✓       |          ✓          |   ✓²   |  ✓³‧⁵ |            |
 
 1. mdcat requires that the terminal supports strikethrough formatting and [inline links][osc8].
    This includes most modern terminal emulators, such as Windows Terminal, KDE Konsole, or anything based on VTE, GNOME's terminal emulation library.
    But mdcat likely won't work well on old terminals that lack these features (e.g. the Linux text console).
 2. SVG images are rendered with [resvg], see [SVG support].
-3. On terminals with the iTerm2 or kitty image protocol, math is rendered as PNG images.
+3. On terminals with the iTerm2, kitty, or Sixel image protocol, math is rendered as PNG images.
    Otherwise mdcat uses Unicode substitutions.
+4. Uses Sixel for images, which is also supported by many other terminals.
+   The capability detection logic would need to be extended to also provide the feature on other terminals, though.
+5. Inline math with Sixel breaks the layout, as it causes vertical scrolling that is not taking into account.
 
 Not supported:
 
@@ -60,6 +64,7 @@ Not supported:
 [SVG support]: https://github.com/RazrFalcon/resvg#svg-support
 [VSCode]: https://code.visualstudio.com/
 [Ghostty]: https://mitchellh.com/ghostty
+[foot]: https://codeberg.org/dnkl/foot
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Then it
 | [VSCode]           |      ✓       |          ✓          |        |  ✓³   |            |
 | [Ghostty]          |      ✓       |          ✓          |   ✓²   |  ✓³   |            |
 | [foot]⁴            |      ✓       |          ✓          |   ✓²   |  ✓³‧⁵ |            |
+| [xterm]⁴           |      ✓       |          ✓          |   ✓²   |  ✓³‧⁵ |            |
 
 1. mdcat requires that the terminal supports strikethrough formatting and [inline links][osc8].
    This includes most modern terminal emulators, such as Windows Terminal, KDE Konsole, or anything based on VTE, GNOME's terminal emulation library.
@@ -65,6 +66,7 @@ Not supported:
 [VSCode]: https://code.visualstudio.com/
 [Ghostty]: https://mitchellh.com/ghostty
 [foot]: https://codeberg.org/dnkl/foot
+[xterm]: https://invisible-island.net/xterm/xterm.html
 
 ## Usage
 

--- a/pulldown-cmark-mdcat/Cargo.toml
+++ b/pulldown-cmark-mdcat/Cargo.toml
@@ -14,9 +14,10 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["svg", "image-processing"]
+default = ["svg", "image-processing", "sixel"]
 svg = ["dep:resvg"]
 image-processing = ["dep:image"]
+sixel = ["image-processing", "dep:icy_sixel"]
 
 [dependencies]
 base64 = { version = "0.22.1", default-features = false, features = ["std"] }
@@ -40,6 +41,7 @@ ratex-parser = "0.1.11"
 ratex-layout = "0.1.11"
 ratex-render = { version = "0.1.11", features = ["embed-fonts"] }
 ratex-types = "0.1.11"
+icy_sixel = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -51,6 +51,8 @@ fn render_math_image(
 ) -> Option<math::MathImage> {
     match settings.terminal_capabilities.image.as_ref()? {
         ImageCapability::Kitty(_) | ImageCapability::ITerm2(_) => {}
+        #[cfg(feature = "sixel")]
+        ImageCapability::Sixel(_) => {}
         ImageCapability::Terminology(_) => return None,
     }
     math::render_math_png(
@@ -76,6 +78,11 @@ fn write_math_image<W: Write>(
         }
         Some(ImageCapability::ITerm2(i)) => {
             i.write_png_data(writer, &img.png)?;
+            false
+        }
+        #[cfg(feature = "sixel")]
+        Some(ImageCapability::Sixel(s)) => {
+            s.write_png_data(writer, &img.png)?;
             false
         }
         Some(ImageCapability::Terminology(_)) | None => return Ok((0, 0, false)),

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -993,6 +993,15 @@ pub fn write_event<'a, W: Write>(
                     write!(writer, "{}", space)?;
                     length += 1;
                 }
+
+                // pre-allocate rows according to the image height to avoid that
+                // the image causes scrolling
+                for _ in 0..img.height_rows {
+                    writeln!(writer)?;
+                }
+                // then move the cursor back to its original position
+                write!(writer, "\x1b[{}A", img.height_rows)?;
+                write!(writer, "\x1b[{}G", u32::from(length) + 1)?;
                 write!(writer, "\x1b7")?;
                 let (img_cols, _img_rows, _) = write_math_image(writer, settings, img, false)?;
                 write!(writer, "\x1b8")?;

--- a/pulldown-cmark-mdcat/src/terminal/capabilities.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities.rs
@@ -50,7 +50,7 @@ impl ImageCapability {
             ImageCapability::Kitty(t) => t,
             #[cfg(feature = "sixel")]
             ImageCapability::Sixel(t) => t,
-         }
+        }
     }
 }
 

--- a/pulldown-cmark-mdcat/src/terminal/capabilities.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities.rs
@@ -10,6 +10,8 @@ use crate::resources::InlineImageProtocol;
 
 pub mod iterm2;
 pub mod kitty;
+#[cfg(feature = "sixel")]
+pub mod sixel;
 pub mod terminology;
 
 /// The capability of basic styling.
@@ -35,6 +37,9 @@ pub enum ImageCapability {
     ITerm2(iterm2::ITerm2Protocol),
     /// The terminal understands the kitty graphics protocol.
     Kitty(kitty::KittyGraphicsProtocol),
+    /// The terminal renders images in the sixel protocol.
+    #[cfg(feature = "sixel")]
+    Sixel(sixel::SixelProtocol),
 }
 
 impl ImageCapability {
@@ -43,7 +48,9 @@ impl ImageCapability {
             ImageCapability::Terminology(t) => t,
             ImageCapability::ITerm2(t) => t,
             ImageCapability::Kitty(t) => t,
-        }
+            #[cfg(feature = "sixel")]
+            ImageCapability::Sixel(t) => t,
+         }
     }
 }
 

--- a/pulldown-cmark-mdcat/src/terminal/capabilities/sixel.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities/sixel.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sixel image support as thin wrapper on top of icy_sixel.
+
+use std::io::{self, Write};
+
+use crate::resources::image::*;
+use icy_sixel::SixelImage;
+use image::GenericImageView;
+
+use crate::resources::MimeData;
+use crate::terminal::size::TerminalSize;
+
+/// Sixel graphics protocol implementation.
+#[derive(Debug, Copy, Clone)]
+pub struct SixelProtocol;
+
+impl SixelProtocol {
+    fn load_image(mime: MimeData) -> io::Result<image::DynamicImage> {
+        match mime.mime_type_essence() {
+            Some("image/svg+xml") => {
+                let png = crate::resources::svg::render_svg_to_png(&mime.data)?;
+
+                image::load_from_memory_with_format(&png, image::ImageFormat::Png)
+                    .map_err(io::Error::other)
+            }
+
+            Some("image/png") => {
+                image::load_from_memory_with_format(&mime.data, image::ImageFormat::Png)
+                    .map_err(io::Error::other)
+            }
+
+            _ => image::load_from_memory(&mime.data).map_err(io::Error::other),
+        }
+    }
+
+    fn render_sixel(writer: &mut dyn Write, img: image::DynamicImage) -> io::Result<()> {
+        let (w, h) = img.dimensions();
+        let rgba = img.to_rgba8();
+
+        let sixel = SixelImage::try_from_rgba(rgba.into_raw(), w as usize, h as usize)
+            .map_err(io::Error::other)?
+            .encode()
+            .map_err(io::Error::other)?;
+        write!(writer, "{sixel}")
+    }
+
+    /// Write raw PNG bytes inline to the terminal.
+    pub fn write_png_data(&self, writer: &mut dyn Write, png_data: &[u8]) -> io::Result<()> {
+        let img = image::load_from_memory_with_format(png_data, image::ImageFormat::Png)
+            .map_err(io::Error::other)?;
+
+        Self::render_sixel(writer, img)
+    }
+}
+
+impl crate::resources::InlineImageProtocol for SixelProtocol {
+    fn write_inline_image(
+        &self,
+        writer: &mut dyn Write,
+        resource_handler: &dyn crate::resources::ResourceUrlHandler,
+        url: &url::Url,
+        terminal_size: TerminalSize,
+    ) -> io::Result<()> {
+        let mime = resource_handler.read_resource(url)?;
+        let image = SixelProtocol::load_image(mime)?;
+
+        let image = if let Some(downsized) = downsize_to_columns(&image, terminal_size) {
+            downsized
+        } else {
+            image
+        };
+
+        SixelProtocol::render_sixel(writer, image)
+    }
+}

--- a/pulldown-cmark-mdcat/src/terminal/capabilities/sixel.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities/sixel.rs
@@ -46,7 +46,7 @@ impl SixelProtocol {
     }
 
     /// Write raw PNG bytes inline to the terminal.
-    pub fn write_png_data(&self, writer: &mut dyn Write, png_data: &[u8]) -> io::Result<()> {
+    pub(crate) fn write_png_data(&self, writer: &mut dyn Write, png_data: &[u8]) -> io::Result<()> {
         let img = image::load_from_memory_with_format(png_data, image::ImageFormat::Png)
             .map_err(io::Error::other)?;
 

--- a/pulldown-cmark-mdcat/src/terminal/detect.rs
+++ b/pulldown-cmark-mdcat/src/terminal/detect.rs
@@ -48,6 +48,10 @@ pub enum TerminalProgram {
     ///
     /// See <https://mitchellh.com/ghostty> for more information.
     Ghostty,
+    /// foot.
+    ///
+    /// See <https://codeberg.org/dnkl/foot> for mor information.
+    Foot,
 }
 
 impl Display for TerminalProgram {
@@ -61,6 +65,7 @@ impl Display for TerminalProgram {
             TerminalProgram::WezTerm => "WezTerm",
             TerminalProgram::VSCode => "vscode",
             TerminalProgram::Ghostty => "ghostty",
+            TerminalProgram::Foot => "foot",
         };
         write!(f, "{name}")
     }
@@ -72,6 +77,7 @@ impl TerminalProgram {
             Some("wezterm") => Some(Self::WezTerm),
             Some("xterm-kitty") => Some(Self::Kitty),
             Some("xterm-ghostty") => Some(Self::Ghostty),
+            Some("foot") => Some(Self::Foot),
             _ => None,
         }
     }
@@ -138,6 +144,11 @@ impl TerminalProgram {
             TerminalProgram::VSCode => ansi,
             TerminalProgram::Ghostty => ansi
                 .with_image_capability(ImageCapability::Kitty(self::kitty::KittyGraphicsProtocol)),
+            #[cfg(feature = "sixel")]
+            TerminalProgram::Foot => ansi
+                .with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol)),
+            #[cfg(not(feature = "sixel"))]
+            TerminalProgram::Foot => ansi,
         }
     }
 }
@@ -262,5 +273,12 @@ mod tests {
             ],
             || assert_eq!(TerminalProgram::detect(), TerminalProgram::Kitty),
         )
+    }
+
+    #[test]
+    pub fn detect_term_foot() {
+        with_vars(vec![("TERM", Some("foot"))], || {
+            assert_eq!(TerminalProgram::detect(), TerminalProgram::Foot)
+        })
     }
 }

--- a/pulldown-cmark-mdcat/src/terminal/detect.rs
+++ b/pulldown-cmark-mdcat/src/terminal/detect.rs
@@ -162,8 +162,9 @@ impl TerminalProgram {
             #[cfg(not(feature = "sixel"))]
             TerminalProgram::Foot => ansi,
             #[cfg(feature = "sixel")]
-            TerminalProgram::Xterm => ansi
-                .with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol)),
+            TerminalProgram::Xterm => {
+                ansi.with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol))
+            }
             #[cfg(not(feature = "sixel"))]
             TerminalProgram::Xterm => ansi,
         }

--- a/pulldown-cmark-mdcat/src/terminal/detect.rs
+++ b/pulldown-cmark-mdcat/src/terminal/detect.rs
@@ -78,12 +78,17 @@ impl Display for TerminalProgram {
 
 impl TerminalProgram {
     fn detect_term() -> Option<Self> {
+        if let Ok(v) = std::env::var("XTERM_VERSION") {
+            if !v.is_empty() {
+                return Some(Self::Xterm);
+            }
+        }
+
         match std::env::var("TERM").ok().as_deref() {
             Some("wezterm") => Some(Self::WezTerm),
             Some("xterm-kitty") => Some(Self::Kitty),
             Some("xterm-ghostty") => Some(Self::Ghostty),
             Some("foot") => Some(Self::Foot),
-            Some("xterm") => Some(Self::Xterm),
             _ => None,
         }
     }
@@ -295,7 +300,7 @@ mod tests {
 
     #[test]
     pub fn detect_term_xterm() {
-        with_vars(vec![("TERM", Some("xterm"))], || {
+        with_vars(vec![("XTERM_VERSION", Some("XTerm(410)"))], || {
             assert_eq!(TerminalProgram::detect(), TerminalProgram::Xterm)
         })
     }

--- a/pulldown-cmark-mdcat/src/terminal/detect.rs
+++ b/pulldown-cmark-mdcat/src/terminal/detect.rs
@@ -156,8 +156,9 @@ impl TerminalProgram {
             TerminalProgram::Ghostty => ansi
                 .with_image_capability(ImageCapability::Kitty(self::kitty::KittyGraphicsProtocol)),
             #[cfg(feature = "sixel")]
-            TerminalProgram::Foot => ansi
-                .with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol)),
+            TerminalProgram::Foot => {
+                ansi.with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol))
+            }
             #[cfg(not(feature = "sixel"))]
             TerminalProgram::Foot => ansi,
             #[cfg(feature = "sixel")]

--- a/pulldown-cmark-mdcat/src/terminal/detect.rs
+++ b/pulldown-cmark-mdcat/src/terminal/detect.rs
@@ -52,6 +52,10 @@ pub enum TerminalProgram {
     ///
     /// See <https://codeberg.org/dnkl/foot> for mor information.
     Foot,
+    /// xterm.
+    ///
+    /// See <https://invisible-island.net/xterm/xterm.html> for mor information.
+    Xterm,
 }
 
 impl Display for TerminalProgram {
@@ -66,6 +70,7 @@ impl Display for TerminalProgram {
             TerminalProgram::VSCode => "vscode",
             TerminalProgram::Ghostty => "ghostty",
             TerminalProgram::Foot => "foot",
+            TerminalProgram::Xterm => "xterm",
         };
         write!(f, "{name}")
     }
@@ -78,6 +83,7 @@ impl TerminalProgram {
             Some("xterm-kitty") => Some(Self::Kitty),
             Some("xterm-ghostty") => Some(Self::Ghostty),
             Some("foot") => Some(Self::Foot),
+            Some("xterm") => Some(Self::Xterm),
             _ => None,
         }
     }
@@ -149,6 +155,11 @@ impl TerminalProgram {
                 .with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol)),
             #[cfg(not(feature = "sixel"))]
             TerminalProgram::Foot => ansi,
+            #[cfg(feature = "sixel")]
+            TerminalProgram::Xterm => ansi
+                .with_image_capability(ImageCapability::Sixel(self::sixel::SixelProtocol)),
+            #[cfg(not(feature = "sixel"))]
+            TerminalProgram::Xterm => ansi,
         }
     }
 }
@@ -279,6 +290,13 @@ mod tests {
     pub fn detect_term_foot() {
         with_vars(vec![("TERM", Some("foot"))], || {
             assert_eq!(TerminalProgram::detect(), TerminalProgram::Foot)
+        })
+    }
+
+    #[test]
+    pub fn detect_term_xterm() {
+        with_vars(vec![("TERM", Some("xterm"))], || {
+            assert_eq!(TerminalProgram::detect(), TerminalProgram::Xterm)
         })
     }
 }


### PR DESCRIPTION
This adds a slim wrapper on top of the [icy_sixel] to render images as sixel.

The implementation has issues with vertical layout, as writing a sixel image causes scrolling if the images is occupying more than one row. This also impacts the current assumption that the sequence:

1. cursor backup
2. `write_math_image()`
3. cursor restore

does result in the cursor being at the same position as before. But due to scrolling, it may be vertically shifted down.

Currently, only support for [foot] and xterm is added. But with the sixel output in place, it would only require adding the capability detection logic to add image support to other terminals that also support sixel.

[icy_sixel]: https://docs.rs/icy_sixel/latest/icy_sixel/
[foot]: https://codeberg.org/dnkl/foo

#### Rendering in of the README of this project in foot

<img width="960" height="1028" alt="20260628_19h24m52s_grim" src="https://github.com/user-attachments/assets/a6c28399-70a7-43f2-bf33-9b75dd2200dd" />

#### Same in xterm

> [!NOTE]
> I had to to start `xterm` as `xterm -ti vt340` for Sixel to work. I didn't care to set up a proper font, as that was needed to test Sixel.

<img width="960" height="1028" alt="20260628_19h27m50s_grim" src="https://github.com/user-attachments/assets/26812623-e219-4027-89ff-4d9312e7463f" />

#### Rendering errors in inline-math

<img width="960" height="1028" alt="20260628_19h34m04s_grim" src="https://github.com/user-attachments/assets/62afbabe-a42c-413c-8dbc-68c42ea758c1" />

Above shows an open issue with the rendering of inline math: output of a sixel image can cause scrolling. If the height of a terminal cell in pixels is not a multiple of 6, the image output has to be padded with transparent pixels to the next multiple of 6 to align the image with the grid.

#### Rendering of inline-math in xterm

<img width="960" height="1028" alt="20260628_19h45m37s_grim" src="https://github.com/user-attachments/assets/a2434c7e-b232-4b79-a33b-d1f4d7f5159e" />

In xterm with the default font the scrolling does not appear, though. I have not confirmed whether this is due to different behavior of `xterm` and `foot` here, or whether a terminal cell just by luck happened to be a multiple of 6 pixels in height.