### PR TITLE
Fix math rendering in table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Use `cargo release` to create a new release.
 - `<br>` inside a table cell now starts a new line within that cell, instead
   of being dropped or printed literally (GH #27).
 
+### Fixed
+- Inline and display math inside table cells now use the Unicode fallback
+  instead of panicking (GH #28).
+
 ## [2.13.0] – 2026-07-21
 
 ### Added

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -1533,6 +1533,17 @@ pub fn write_event<'a, W: Write>(
             };
             Stacked(stack, TableBlock(attrs)).and_data(data).ok()
         }
+        (Stacked(stack, TableBlock(attrs)), InlineMath(math) | DisplayMath(math)) => {
+            let rendered = math::render_math_unicode(&math);
+            let current_table = data
+                .current_table
+                .push_styled_text(rendered.into(), settings.theme.math_style);
+            let data = StateData {
+                current_table,
+                ..data
+            };
+            Stacked(stack, TableBlock(attrs)).and_data(data).ok()
+        }
         (Stacked(stack, TableBlock(attrs)), End(TagEnd::Table)) => {
             let (prefix, prefix_cols) = quote_line_prefix(
                 &settings.terminal_capabilities,

--- a/pulldown-cmark-mdcat/tests/render.rs
+++ b/pulldown-cmark-mdcat/tests/render.rs
@@ -159,6 +159,25 @@ fn table_as_first_list_item_block_does_not_panic() {
 }
 
 #[test]
+fn math_in_table_cells_does_not_panic() {
+    let settings = Settings {
+        terminal_capabilities: TerminalProgram::Dumb.capabilities(),
+        terminal_size: TerminalSize::default(),
+        theme: Theme::default(),
+        syntax_set: syntax_set(),
+        syntax_theme: None,
+    };
+    let cwd = std::env::current_dir().expect("Require working directory");
+    let output = render_markdown_to_string(
+        "| Math |\n| - |\n| $\\alpha$ |\n| $$\\frac{1}{2}$$ |",
+        &cwd,
+        &settings,
+    );
+
+    assert_eq!(output, "──────\n Math \n──────\n α    \n 1/2  \n──────\n");
+}
+
+#[test]
 fn inline_math_kitty_placement_does_not_move_cursor() {
     let settings = Settings {
         terminal_capabilities: TerminalProgram::Kitty.capabilities(),


### PR DESCRIPTION
Closes #28.

## What changed

- Handle `InlineMath` and `DisplayMath` events while collecting table cells.
- Render table-cell math through the existing Unicode fallback, preserving the configured math style and avoiding image/cursor operations inside table layout.
- Add a regression test covering both math event types.
- Document the fix in the changelog.

## Root cause

The `TableBlock` renderer handled text, code, emphasis, links, images, and inline HTML, but had no match arm for either math event. With math parsing enabled, a table cell such as `$x$` therefore fell through to the renderer's impossible-event panic. Currency comparisons such as `$0.65 → **$0.07**` can trigger the same parser event.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p pulldown-cmark-mdcat --all-targets --locked --no-default-features`
- `cargo test -p pulldown-cmark-mdcat --locked --no-default-features`
- `cargo clippy --workspace --all-targets --locked`
- `cargo test --workspace --locked`
- Re-ran the original `lesspipe.py README.md` path with the patched `mdcat`: exit 0, empty stderr