### PR TITLE
feat: write the quote prefix on list lines

### DIFF
--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -535,7 +535,7 @@ pub fn write_event<'a, W: Write>(
             // one on the wrapped line then appears to sit inside the text.
             // It precedes the indent, being the start of the line rather than
             // part of what is indented.
-            let (quote_prefix, quote_prefix_cols) = quote_line_prefix(
+            let (quote_prefix, _) = quote_line_prefix(
                 &settings.terminal_capabilities,
                 &settings.theme,
                 quote_depth,
@@ -564,7 +564,10 @@ pub fn write_event<'a, W: Write>(
                     },
                 ))
                 .and_data(data.current_line(CurrentLine {
-                    length: indent + quote_prefix_cols,
+                    // Not the prefix's width: the wrapping already sets that
+                    // aside by shrinking the width available to the text.
+                    // Counting it here as well wraps the line early.
+                    length: indent,
                     trailing_space: None,
                 }))
                 .ok()
@@ -574,6 +577,16 @@ pub fn write_event<'a, W: Write>(
                 // Write margin, unless we're at the start of the list item in which case the first line of the
                 // paragraph should go right beside the item bullet.
                 writeln!(writer)?;
+                // A later block of the item begins a line of its own, and
+                // inside a quote that line carries the prefix as the bullet
+                // line does -- otherwise the two stop lining up.
+                let (prefix, _) = quote_line_prefix(
+                    &settings.terminal_capabilities,
+                    &settings.theme,
+                    attrs.quote_depth,
+                    attrs.border_style,
+                );
+                write!(writer, "{}", prefix)?;
                 write_indent(writer, attrs.indent)?;
             }
             stack

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -529,6 +529,19 @@ pub fn write_event<'a, W: Write>(
                 // Add margin
                 writeln!(writer)?;
             }
+            // Inside a block quote every line carries the quote prefix, and
+            // the continuation lines of a wrapped item already write it.
+            // Without it here the bullet line alone lacks the prefix, and the
+            // one on the wrapped line then appears to sit inside the text.
+            // It precedes the indent, being the start of the line rather than
+            // part of what is indented.
+            let (quote_prefix, quote_prefix_cols) = quote_line_prefix(
+                &settings.terminal_capabilities,
+                &settings.theme,
+                quote_depth,
+                attrs.border_style,
+            );
+            write!(writer, "{}", quote_prefix)?;
             write_indent(writer, indent)?;
             let indent = match kind {
                 ListItemKind::Unordered => {
@@ -551,7 +564,7 @@ pub fn write_event<'a, W: Write>(
                     },
                 ))
                 .and_data(data.current_line(CurrentLine {
-                    length: indent,
+                    length: indent + quote_prefix_cols,
                     trailing_space: None,
                 }))
                 .ok()

--- a/pulldown-cmark-mdcat/src/render/write.rs
+++ b/pulldown-cmark-mdcat/src/render/write.rs
@@ -61,8 +61,8 @@ fn write_remaining_lines<W: Write>(
 ) -> Result<CurrentLine> {
     // Finish the previous line
     writeln!(writer)?;
-    write_indent(writer, indent)?;
     write!(writer, "{}", line_prefix)?;
+    write_indent(writer, indent)?;
     // Now write all lines up to the last
     for line in next_lines {
         match line.split_last() {
@@ -77,8 +77,8 @@ fn write_remaining_lines<W: Write>(
                 buffer.push_str(last.word);
                 write_styled(writer, capabilities, style, &buffer)?;
                 writeln!(writer)?;
-                write_indent(writer, indent)?;
                 write!(writer, "{}", line_prefix)?;
+                write_indent(writer, indent)?;
                 buffer.clear();
             }
         };
@@ -139,8 +139,8 @@ pub fn write_styled_and_wrapped<W: Write, S: AsRef<str>>(
                 && max_width < current_width + display_width(first_word) as u16
             {
                 writeln!(writer)?;
-                write_indent(writer, indent)?;
                 write!(writer, "{}", line_prefix)?;
+                write_indent(writer, indent)?;
                 return write_styled_and_wrapped(
                     writer,
                     capabilities,

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-235-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-235-block_quotes.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/235-block_quotes.md
 ---
-• [3mfoo[0m
+[36m│[0m • [3mfoo[0m
 
 • bar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-259-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-259-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/259-list_items.md
 ---
- 1. [3mone[0m
+[36m│[0m [36m│[0m  1. [3mone[0m
 
-    [3mtwo[0m
+[36m│[0m [36m│[0m     [3mtwo[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-260-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-260-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/260-list_items.md
 ---
-• [3mone[0m
+[36m│[0m [36m│[0m • [3mone[0m
 [36m│[0m [36m│[0m 
 [36m│[0m [36m│[0m [3mtwo[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-292-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-292-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/292-list_items.md
 ---
- 1. 
+[36m│[0m  1. 
     [36m│[0m [3mBlockquote[0m[3m continued here.[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-293-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-293-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/293-list_items.md
 ---
- 1. 
+[36m│[0m  1. 
     [36m│[0m [3mBlockquote[0m[3m continued here.[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-235-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-235-block_quotes.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/235-block_quotes.md
 ---
-• foo
+  • foo
 
 • bar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-259-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-259-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/259-list_items.md
 ---
- 1. one
+     1. one
 
-    two
+        two

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-260-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-260-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/260-list_items.md
 ---
-• one
+    • one
     
     two

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-292-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-292-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/292-list_items.md
 ---
- 1. 
+   1. 
       Blockquote continued here.

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-293-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-293-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/293-list_items.md
 ---
- 1. 
+   1. 
       Blockquote continued here.

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-235-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-235-block_quotes.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/235-block_quotes.md
 ---
-• [3mfoo[0m
+[36m│[0m • [3mfoo[0m
 
 • bar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-259-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-259-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/259-list_items.md
 ---
- 1. [3mone[0m
+[36m│[0m [36m│[0m  1. [3mone[0m
 
-    [3mtwo[0m
+[36m│[0m [36m│[0m     [3mtwo[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-260-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-260-list_items.snap
@@ -1,8 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/260-list_items.md
 ---
-• [3mone[0m
+[36m│[0m [36m│[0m • [3mone[0m
 [36m│[0m [36m│[0m 
 [36m│[0m [36m│[0m [3mtwo[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-292-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-292-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/292-list_items.md
 ---
- 1. 
+[36m│[0m  1. 
     [36m│[0m [3mBlockquote[0m[3m continued here.[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-293-list_items.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-293-list_items.snap
@@ -1,7 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/293-list_items.md
 ---
- 1. 
+[36m│[0m  1. 
     [36m│[0m [3mBlockquote[0m[3m continued here.[0m


### PR DESCRIPTION
A list nested in a block quote rendered without the prefix its surrounding paragraphs carry, and a wrapped item then had one appear inside its text:

    │ quoted text

    • one
    • two that is long enough to wrap at the
      │ terminal width and keep going

Both follow from the same thing. Every line inside a quote is written with the prefix, but the list item path never wrote it, while the wrapping path wrote it after the indent rather than before -- so the only lines carrying a prefix were the continuation lines, and there it landed in the middle of the text.

Write it when starting an item, before the indent, and count its width towards the current line so wrapping still measures correctly. Order it before the indent when wrapping too, the prefix being the start of the line rather than part of what is indented.

    │ quoted text

    │ • one
    │ • two that is long enough to wrap at the
    │   terminal width and keep going

Nested lists follow from the same change, and lists outside a quote are unaffected: with no quote depth the prefix is empty and nothing is written.