### PR TITLE
feat: write the quote prefix on code block lines

### DIFF
--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -310,7 +310,14 @@ pub fn write_event<'a, W: Write>(
 
             State::stack_onto(TopLevelAttrs::margin_before())
                 .current(write_start_code_block(
-                    writer, settings, 0, Style::new(), 0, None, true, kind,
+                    writer,
+                    settings,
+                    0,
+                    Style::new(),
+                    0,
+                    None,
+                    true,
+                    kind,
                 )?)
                 .and_data(data)
                 .ok()
@@ -1025,10 +1032,14 @@ pub fn write_event<'a, W: Write>(
                 border_style,
             );
             for line in LinesWithEndings::from(&text) {
+                write_indent(writer, indent)?;
                 write_styled(writer, &settings.terminal_capabilities, &style, line)?;
                 if !line.ends_with('\n') {
                     writeln!(writer)?;
                 }
+                // The prefix belongs to the line just begun, ahead of the
+                // indent written for it. Empty outside a quote, leaving the
+                // surrounding writes exactly as they were.
                 write!(writer, "{}", prefix)?;
                 write_indent(writer, indent)?;
             }
@@ -1108,6 +1119,7 @@ pub fn write_event<'a, W: Write>(
                     .parse_state
                     .parse_line(line, settings.syntax_set)
                     .expect("syntect parsing shouldn't fail in mdcat");
+                write_indent(writer, attrs.indent)?;
                 match &settings.syntax_theme {
                     Some(theme) => {
                         let h = highlighter_for(theme);

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -83,7 +83,7 @@ fn write_alert_label<W: Write>(
     writeln!(writer)
 }
 
-fn quote_line_prefix(
+pub(super) fn quote_line_prefix(
     capabilities: &TerminalCapabilities,
     theme: &Theme,
     depth: u16,
@@ -310,11 +310,7 @@ pub fn write_event<'a, W: Write>(
 
             State::stack_onto(TopLevelAttrs::margin_before())
                 .current(write_start_code_block(
-                    writer,
-                    settings,
-                    0,
-                    Style::new(),
-                    kind,
+                    writer, settings, 0, Style::new(), 0, None, true, kind,
                 )?)
                 .and_data(data)
                 .ok()
@@ -505,13 +501,37 @@ pub fn write_event<'a, W: Write>(
         }
         (Stacked(stack, StyledBlock(attrs)), Start(CodeBlock(kind))) => {
             if attrs.margin_before != NoMargin {
+                // The blank line separating this block from the last is still
+                // a line of the quote, and carries its prefix like the others.
+                let (margin_prefix, _) = quote_line_prefix(
+                    &settings.terminal_capabilities,
+                    &settings.theme,
+                    attrs.quote_depth,
+                    attrs.border_style,
+                );
+                write_indent(writer, attrs.indent)?;
+                write!(writer, "{}", margin_prefix)?;
                 writeln!(writer)?;
             }
-            let StyledBlockAttrs { indent, style, .. } = attrs;
+            // Read before the value is consumed by the push below.
+            let StyledBlockAttrs {
+                indent,
+                style,
+                quote_depth,
+                border_style,
+                ..
+            } = attrs;
             stack
                 .push(attrs.into())
                 .current(write_start_code_block(
-                    writer, settings, indent, style, kind,
+                    writer,
+                    settings,
+                    indent,
+                    style,
+                    quote_depth,
+                    border_style,
+                    false,
+                    kind,
                 )?)
                 .and_data(data)
                 .ok()
@@ -592,10 +612,24 @@ pub fn write_event<'a, W: Write>(
         }
         (Stacked(stack, Inline(ListItem(kind, _), attrs)), Start(CodeBlock(ck))) => {
             writeln!(writer)?;
-            let InlineAttrs { indent, style, .. } = attrs;
+            let InlineAttrs {
+                indent,
+                style,
+                quote_depth,
+                border_style,
+            } = attrs.clone();
             stack
                 .push(Inline(ListItem(kind, ItemBlock), attrs))
-                .current(write_start_code_block(writer, settings, indent, style, ck)?)
+                .current(write_start_code_block(
+                    writer,
+                    settings,
+                    indent,
+                    style,
+                    quote_depth,
+                    border_style,
+                    true,
+                    ck,
+                )?)
                 .and_data(data)
                 .ok()
         }
@@ -840,10 +874,24 @@ pub fn write_event<'a, W: Write>(
         }
         (Stacked(stack, Inline(Definition(part, _), attrs)), Start(CodeBlock(ck))) => {
             writeln!(writer)?;
-            let InlineAttrs { indent, style, .. } = attrs;
+            let InlineAttrs {
+                indent,
+                style,
+                quote_depth,
+                border_style,
+            } = attrs.clone();
             stack
                 .push(Inline(Definition(part, ItemBlock), attrs))
-                .current(write_start_code_block(writer, settings, indent, style, ck)?)
+                .current(write_start_code_block(
+                    writer,
+                    settings,
+                    indent,
+                    style,
+                    quote_depth,
+                    border_style,
+                    true,
+                    ck,
+                )?)
                 .and_data(data)
                 .ok()
         }
@@ -964,16 +1012,38 @@ pub fn write_event<'a, W: Write>(
 
         // Literal blocks without highlighting
         (Stacked(stack, LiteralBlock(attrs)), Text(text)) => {
-            let LiteralBlockAttrs { indent, style, .. } = attrs;
+            let LiteralBlockAttrs {
+                indent,
+                style,
+                quote_depth,
+                border_style,
+            } = attrs;
+            let (prefix, _) = quote_line_prefix(
+                &settings.terminal_capabilities,
+                &settings.theme,
+                quote_depth,
+                border_style,
+            );
             for line in LinesWithEndings::from(&text) {
-                write_indent(writer, indent)?;
                 write_styled(writer, &settings.terminal_capabilities, &style, line)?;
                 if !line.ends_with('\n') {
                     writeln!(writer)?;
                 }
+                write!(writer, "{}", prefix)?;
                 write_indent(writer, indent)?;
             }
-            stack.current(attrs.into()).and_data(data).ok()
+            stack
+                .current(
+                    LiteralBlockAttrs {
+                        indent,
+                        style,
+                        quote_depth,
+                        border_style,
+                    }
+                    .into(),
+                )
+                .and_data(data)
+                .ok()
         }
         (Stacked(stack, LiteralBlock(_)), End(TagEnd::CodeBlock)) => {
             write_code_block_border(
@@ -1027,12 +1097,17 @@ pub fn write_event<'a, W: Write>(
 
         // Highlighted code blocks
         (Stacked(stack, HighlightBlock(mut attrs)), Text(text)) => {
+            let (prefix, _) = quote_line_prefix(
+                &settings.terminal_capabilities,
+                &settings.theme,
+                attrs.quote_depth,
+                attrs.border_style,
+            );
             for line in LinesWithEndings::from(&text) {
                 let ops = attrs
                     .parse_state
                     .parse_line(line, settings.syntax_set)
                     .expect("syntect parsing shouldn't fail in mdcat");
-                write_indent(writer, attrs.indent)?;
                 match &settings.syntax_theme {
                     Some(theme) => {
                         let h = highlighter_for(theme);
@@ -1050,6 +1125,7 @@ pub fn write_event<'a, W: Write>(
                         highlighting::write_as_ansi(writer, regions)?;
                     }
                 }
+                write!(writer, "{}", prefix)?;
                 write_indent(writer, attrs.indent)?;
             }
             stack.current(attrs.into()).and_data(data).ok()
@@ -1070,7 +1146,18 @@ pub fn write_event<'a, W: Write>(
             stack.current(attrs.into()).and_data(data).ok()
         }
         (Stacked(stack, MermaidBlock(attrs)), End(TagEnd::CodeBlock)) => {
-            let MermaidBlockAttrs { indent, source } = attrs;
+            let MermaidBlockAttrs {
+                indent,
+                source,
+                quote_depth,
+                border_style,
+            } = attrs;
+            let (prefix, _) = quote_line_prefix(
+                &settings.terminal_capabilities,
+                &settings.theme,
+                quote_depth,
+                border_style,
+            );
             if let Some(img) = render_mermaid_image(settings, &source) {
                 let (_, _, cursor_moved) = write_mermaid_image(writer, settings, img, true)?;
                 if !cursor_moved {
@@ -1078,6 +1165,7 @@ pub fn write_event<'a, W: Write>(
                 }
             } else if let Some(text) = mermaid::render_mermaid_text(&source) {
                 for line in LinesWithEndings::from(&text) {
+                    write!(writer, "{}", prefix)?;
                     write_indent(writer, indent)?;
                     write_styled(
                         writer,
@@ -1091,6 +1179,7 @@ pub fn write_event<'a, W: Write>(
                 }
             } else {
                 for line in LinesWithEndings::from(&source) {
+                    write!(writer, "{}", prefix)?;
                     write_indent(writer, indent)?;
                     write_styled(
                         writer,

--- a/pulldown-cmark-mdcat/src/render/state.rs
+++ b/pulldown-cmark-mdcat/src/render/state.rs
@@ -230,6 +230,10 @@ pub struct HighlightBlockAttrs {
     /// Code blocks in nested blocks such as quotes, lists, etc. gain an additional indent to align
     /// them in the surrounding block.
     pub(super) indent: u16,
+    /// The block quote depth this code block sits at.
+    pub(super) quote_depth: u16,
+    /// The style of the block quote border, if any.
+    pub(super) border_style: Option<Style>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -238,6 +242,10 @@ pub struct LiteralBlockAttrs {
     pub(super) indent: u16,
     /// The outer style to include.
     pub(super) style: Style,
+    /// The block quote depth this code block sits at.
+    pub(super) quote_depth: u16,
+    /// The style of the block quote border, if any.
+    pub(super) border_style: Option<Style>,
 }
 
 /// Attributes for a Mermaid diagram block, collecting source text until it's fully read and can
@@ -248,6 +256,10 @@ pub struct MermaidBlockAttrs {
     pub(super) indent: u16,
     /// The diagram source accumulated so far.
     pub(super) source: String,
+    /// The block quote depth this diagram sits at.
+    pub(super) quote_depth: u16,
+    /// The style of the block quote border, if any.
+    pub(super) border_style: Option<Style>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -267,7 +279,9 @@ pub enum StackedState {
     /// A block with attached style.
     StyledBlock(StyledBlockAttrs),
     /// A highlighted block of code.
-    HighlightBlock(HighlightBlockAttrs),
+    /// Boxed: it carries syntect's parse and highlight state, which is far
+    /// larger than anything else here.
+    HighlightBlock(Box<HighlightBlockAttrs>),
     /// A literal block without highlighting.
     LiteralBlock(LiteralBlockAttrs),
     /// A Mermaid diagram block, accumulating source text.
@@ -295,6 +309,12 @@ impl From<StyledBlockAttrs> for StackedState {
 
 impl From<HighlightBlockAttrs> for StackedState {
     fn from(attrs: HighlightBlockAttrs) -> Self {
+        StackedState::HighlightBlock(Box::new(attrs))
+    }
+}
+
+impl From<Box<HighlightBlockAttrs>> for StackedState {
+    fn from(attrs: Box<HighlightBlockAttrs>) -> Self {
         StackedState::HighlightBlock(attrs)
     }
 }

--- a/pulldown-cmark-mdcat/src/render/write.rs
+++ b/pulldown-cmark-mdcat/src/render/write.rs
@@ -13,6 +13,8 @@ use pulldown_cmark::{Alignment, CodeBlockKind, CowStr, HeadingLevel};
 use syntect::highlighting::HighlightState;
 use syntect::parsing::{ParseState, ScopeStack};
 use textwrap::core::{display_width, Word};
+
+use super::quote_line_prefix;
 use textwrap::WordSeparator;
 
 use crate::references::*;
@@ -303,14 +305,30 @@ pub fn write_link_refs<W: Write>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn write_start_code_block<W: Write>(
     writer: &mut W,
     settings: &Settings,
     indent: u16,
     style: Style,
+    quote_depth: u16,
+    border_style: Option<Style>,
+    // Whether the current line still needs ending. A caller that has just
+    // written a margin line of its own has ended it already, and a second
+    // newline here would leave a blank line with no quote prefix on it.
+    end_current_line: bool,
     block_kind: CodeBlockKind<'_>,
 ) -> Result<StackedState> {
-    writeln!(writer)?;
+    if end_current_line {
+        writeln!(writer)?;
+    }
+    let (prefix, _) = quote_line_prefix(
+        &settings.terminal_capabilities,
+        &settings.theme,
+        quote_depth,
+        border_style,
+    );
+    write!(writer, "{}", prefix)?;
     // And start the indent for the contents of the block
     write_indent(writer, indent)?;
 
@@ -319,6 +337,8 @@ pub fn write_start_code_block<W: Write>(
             Ok(MermaidBlockAttrs {
                 indent,
                 source: String::new(),
+                quote_depth,
+                border_style,
             }
             .into())
         }
@@ -327,6 +347,8 @@ pub fn write_start_code_block<W: Write>(
                 None => Ok(LiteralBlockAttrs {
                     indent,
                     style: settings.theme.code_style.on_top_of(&style),
+                    quote_depth,
+                    border_style,
                 }
                 .into()),
                 Some(syntax) => {
@@ -336,6 +358,8 @@ pub fn write_start_code_block<W: Write>(
                         indent,
                         highlight_state,
                         parse_state,
+                        quote_depth,
+                        border_style,
                     }
                     .into())
                 }
@@ -344,6 +368,8 @@ pub fn write_start_code_block<W: Write>(
         (_, _) => Ok(LiteralBlockAttrs {
             indent,
             style: settings.theme.code_style.on_top_of(&style),
+            quote_depth,
+            border_style,
         }
         .into()),
     }

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-006-tabs.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-006-tabs.snap
@@ -1,9 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/006-tabs.md
 ---
-
-[3m[33m  [0m
-[3m[33mfoo
-[0m
+[36m│[0m [3m[33m  [0m
+[36m│[0m [3m[33mfoo
+[0m[36m│[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-128-fenced_code_blocks.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-128-fenced_code_blocks.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/128-fenced_code_blocks.md
 ---
-
-[3m[33maaa
-[0m
+[36m│[0m [3m[33maaa
+[0m[36m│[0m 
 
 bbb

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-236-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-236-block_quotes.snap
@@ -1,11 +1,11 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/236-block_quotes.md
 ---
-
-[3m[33mfoo
-[0m
+[36m│[0m [3m[33mfoo
+[0m[36m│[0m 
 
 
 [33mbar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-237-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-237-block_quotes.snap
@@ -1,9 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/237-block_quotes.md
 ---
-
-
+[36m│[0m 
 
 foo

--- a/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-252-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/ansi@commonmark-spec-252-block_quotes.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 121
 expression: "render_to_string(markdown_file, &ansi_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/252-block_quotes.md
 ---
-
-[3m[33mcode
-[0m
+[36m│[0m [3m[33mcode
+[0m[36m│[0m 
 
 [36m│[0m [3mnot code[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-006-tabs.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-006-tabs.snap
@@ -1,8 +1,8 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/006-tabs.md
 ---
-
-  
-foo
+    
+  foo

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-128-fenced_code_blocks.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-128-fenced_code_blocks.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/128-fenced_code_blocks.md
 ---
-
-aaa
-
+  aaa
+  
 
 bbb

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-236-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-236-block_quotes.snap
@@ -1,11 +1,11 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/236-block_quotes.md
 ---
-
-foo
-
+  foo
+  
 
 
 bar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-237-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-237-block_quotes.snap
@@ -1,9 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/237-block_quotes.md
 ---
-
-
+  
 
 foo

--- a/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-252-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/dumb@commonmark-spec-252-block_quotes.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 120
 expression: "render_to_string(markdown_file, &dumb_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/252-block_quotes.md
 ---
-
-code
-
+  code
+  
 
   not code

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-006-tabs.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-006-tabs.snap
@@ -1,9 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/006-tabs.md
 ---
-
-[3m[33m  [0m
-[3m[33mfoo
-[0m
+[36m│[0m [3m[33m  [0m
+[36m│[0m [3m[33mfoo
+[0m[36m│[0m

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-128-fenced_code_blocks.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-128-fenced_code_blocks.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/128-fenced_code_blocks.md
 ---
-
-[3m[33maaa
-[0m
+[36m│[0m [3m[33maaa
+[0m[36m│[0m 
 
 bbb

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-236-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-236-block_quotes.snap
@@ -1,11 +1,11 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/236-block_quotes.md
 ---
-
-[3m[33mfoo
-[0m
+[36m│[0m [3m[33mfoo
+[0m[36m│[0m 
 
 
 [33mbar

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-237-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-237-block_quotes.snap
@@ -1,9 +1,9 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/237-block_quotes.md
 ---
-
-
+[36m│[0m 
 
 foo

--- a/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-252-block_quotes.snap
+++ b/pulldown-cmark-mdcat/tests/snapshots/render/iterm2@commonmark-spec-252-block_quotes.snap
@@ -1,10 +1,10 @@
 ---
 source: pulldown-cmark-mdcat/tests/render.rs
+assertion_line: 122
 expression: "render_to_string(markdown_file, &iterm2_settings)"
 input_file: pulldown-cmark-mdcat/tests/markdown/commonmark-spec/252-block_quotes.md
 ---
-
-[3m[33mcode
-[0m
+[36m│[0m [3m[33mcode
+[0m[36m│[0m 
 
 [36m│[0m [3mnot code[0m


### PR DESCRIPTION
A code block inside a block quote rendered with no prefix at all, so it broke out of the quote it belongs to:

    │ quoted text

    echo hello
    echo world

    │
    │ after the block

The code block states carried the indent but not the quote depth, so there was nothing to render a prefix from once inside one. Carry the depth and the border style on the literal, highlighted and Mermaid block states, write the prefix when the block starts and at the start of each line of its contents, and prefix the margin line before the block as the paragraph path already does.

    │ quoted text
    │
    │ echo hello
    │ echo world
    │
    │ after the block

write_start_code_block gains a flag for whether the current line still needs ending: the caller inside a quote has just written a margin line itself, and a second newline there left a blank line with no prefix.

StackedState::HighlightBlock is boxed. It carries syntect's parse and highlight state and was already by far the largest variant; the two extra fields pushed the enum past the large_enum_variant threshold, which this crate denies.

Code blocks outside a quote are unaffected: with no quote depth the prefix is empty and nothing is written.