### PR TITLE
Bump pulldown-cmark to 0.13.4 to fix deflist-in-blockquote panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
  "ignore",
  "mime",
  "notify",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.4",
  "pulldown-cmark-mdcat",
  "serde",
  "shell-words",
@@ -2086,7 +2086,7 @@ dependencies = [
  "indexmap",
  "manatee",
  "merman-core",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.2",
  "roughr-merman",
  "rustc-hash",
  "ryu-js",
@@ -2768,6 +2768,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
 name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,7 +2799,7 @@ dependencies = [
  "merman",
  "mime",
  "png 0.18.1",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.4",
  "ratatui",
  "ratatui-image",
  "ratex-layout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 mime = { version = "0.3.17", default-features = false }
-pulldown-cmark = { version = "0.12.1", default-features = false }
+pulldown-cmark = { version = "0.13.4", default-features = false }
 similar-asserts = "1.6.0"
 syntect = { version = "5.2.0", default-features = false, features = ["regex-fancy"] }
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"]  }


### PR DESCRIPTION
Fixes #46.

Pulldown-cmark 0.12.2 panics on a definition list inside a blockquote terminated
by a blank line (`unwrap()` on `None` in `FirstPass::pop`, firstpass.rs:1540) —
see the linked issue. Upstream fixed it in pulldown-cmark 0.13.0 (PR
pulldown-cmark#974); this bumps the workspace dependency still pinned to 0.12.x.

## Changes

- `Cargo.toml` (`[workspace.dependencies]`): `pulldown-cmark` `0.12.1` → `0.13.4` — a single shared line inherited by both `mdcat` and `pulldown-cmark-mdcat` (`simd` feature unchanged — still exists upstream)
- `Cargo.lock` regenerated: both workspace crates now resolve to 0.13.4

`merman-render` 0.7.0 keeps its own private `pulldown-cmark 0.12.2` copy (it does
not exchange parser types with mdcat), so the lock holds both versions and merman
needs no change.

## Verification

- Panic repro (`printf '> term\n> : definition\n\n' | mdcat`) — panics on 2.16.0 (exit 101), exits 0 on this branch
- Followed-by-paragraph variant and stdin variant also panic before, exit 0 after
- Full workspace suite: 82 + 10 + 1 tests in `pulldown-cmark-mdcat`, 19 + 18 in `mdcat` — 0 failed with both crates on 0.13.4
- `cargo check` clean on the whole workspace
